### PR TITLE
fix(docker): change postgres storage to a volume instead of local dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   postgres:
     image: postgres:10.4
     volumes:
-      - ./services/postgres/.dbdata/.pgsql-data:/var/lib/postgresql/data
+      - postgres-data-volume:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     environment:
@@ -81,6 +81,9 @@ services:
       - graphql-engine
       - serve
       - --enable-console
+
+volumes:
+  postgres-data-volume:
 
 networks:
   default:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo "Building postgres docker volume"
+docker volume create --name=postgres-data-volume
+
 echo "Starting docker containers"
 docker-compose up -d
 


### PR DESCRIPTION
Docker-for-windows doesn't play nicely with external local storage for mongodb. The solution, for now, is to use an explicit docker volume. This isn't necessary for other environments, but it does help bring in another to the project (Windows).

Same treatment given on `eos-local` @ https://github.com/eoscostarica/eos-local/pull/76