### PR TITLE
fix(docker): no longer need to remove a non-existent directory

### DIFF
--- a/scripts/flush.sh
+++ b/scripts/flush.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Flushing all blockchain and databases data"
-docker-compose down -v && rm -rf ./services/postgres/.dbdata
+docker-compose down -v


### PR DESCRIPTION
As a result of changing postgres to a docker volume, we no longer need to remove the external directory that was acting as a volume.

Missed this in the previous PR, my mistake.